### PR TITLE
beginnings of rpi support

### DIFF
--- a/raspberrypi/cloakcoin-rpi-qt.sh
+++ b/raspberrypi/cloakcoin-rpi-qt.sh
@@ -1,0 +1,9 @@
+sudo apt-get update
+sudo apt-get install curl libcurl3 libcurl3-gnutls -y
+cd /opt
+sudo mkdir -vp cloakcoin/2.0.2.1_defender
+cd /opt/cloakcoin/2.0.2.1_defender
+sudo wget https://github.com/CloakProject/2.0.2.1-Wallets/raw/master/cloakCoin_qt-daemon_linux_x64_v2.0.2.1.defender.zip
+sudo unzip cloakCoin_qt-daemon_linux_x64_v2.0.2.1.defender.zip
+sudo chmod +x cloakcoin*
+sudo ln -s /opt/cloakcoin/2.0.2.1_defender/cloakcoin-qt /usr/local/bin/cloakcoin


### PR DESCRIPTION
submitting this as a discussion point. please do not pull this yet until #12 is resolved

As part of supporting raspbian, I am proposing having an installer script that people can run like this on standard raspbian to support CloakCoin.

On the pre-installed images, we can then have this same script sat on the desktop, and as soon as the customer gets it they can double click, click "Execute in terminal" and then it will install the wallet.

At that point we can then duplicated that same image, without any fear of duplicating private keys etc.

See #12 also - as this will only install correctly once we have a version of the binary compiled for the correct architecture. But thought it would be useful to have this discussion concurrently.